### PR TITLE
[FEATURE] - Provider RBAC

### DIFF
--- a/charts/crds/terraform.appvia.io_providers.yaml
+++ b/charts/crds/terraform.appvia.io_providers.yaml
@@ -59,6 +59,70 @@ spec:
                       description: Namespace defines the space within which the secret name must be unique.
                       type: string
                   type: object
+                selector:
+                  description: Selector provider the ability to filter who can use this provider. If empty, all users in the cluster is permitted to use the provider. Otherrise you can specify a selector which can use namespace and resource labels
+                  properties:
+                    namespace:
+                      description: Namespace provides the ability to filter on the namespace
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    resource:
+                      description: Resource provides the ability to filter on the resource labels
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                  type: object
                 serviceAccount:
                   description: ServiceAccount is the name of a service account to use when the provider source is 'injected'. The service account should exist in the terraform controller namespace and be configure per cloud vendor requirements for pod identity.
                   type: string

--- a/charts/crds/terraform.appvia.io_providers.yaml
+++ b/charts/crds/terraform.appvia.io_providers.yaml
@@ -63,7 +63,7 @@ spec:
                   description: Selector provider the ability to filter who can use this provider. If empty, all users in the cluster is permitted to use the provider. Otherrise you can specify a selector which can use namespace and resource labels
                   properties:
                     namespace:
-                      description: Namespace provides the ability to filter on the namespace
+                      description: Namespace is used to filter a configuration based on the namespace labels of where it exists
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -93,7 +93,7 @@ spec:
                           type: object
                       type: object
                     resource:
-                      description: Resource provides the ability to filter on the resource labels
+                      description: Resource provides the ability to filter a configuration based on it's labels
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.

--- a/pkg/apis/terraform/v1alpha1/provider_types.go
+++ b/pkg/apis/terraform/v1alpha1/provider_types.go
@@ -74,6 +74,11 @@ type ProviderSpec struct {
 	// The secret should include the environment variables required to by the terraform provider.
 	// +kubebuilder:validation:Optional
 	SecretRef *v1.SecretReference `json:"secretRef,omitempty"`
+	// Selector provider the ability to filter who can use this provider. If empty, all users
+	// in the cluster is permitted to use the provider. Otherrise you can specify a selector
+	// which can use namespace and resource labels
+	// +kubebuilder:validation:Optional
+	Selector *Selector `json:"selector,omitempty"`
 	// ServiceAccount is the name of a service account to use when the provider source is 'injected'. The
 	// service account should exist in the terraform controller namespace and be configure per cloud vendor
 	// requirements for pod identity.

--- a/pkg/apis/terraform/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/terraform/v1alpha1/zz_generated.deepcopy.go
@@ -478,6 +478,11 @@ func (in *ProviderSpec) DeepCopyInto(out *ProviderSpec) {
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
+	if in.Selector != nil {
+		in, out := &in.Selector, &out.Selector
+		*out = new(Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ServiceAccount != nil {
 		in, out := &in.ServiceAccount, &out.ServiceAccount
 		*out = new(string)

--- a/pkg/assets/assets_test.go
+++ b/pkg/assets/assets_test.go
@@ -21,8 +21,9 @@ import (
 	"html/template"
 	"testing"
 
-	"github.com/appvia/terraform-controller/pkg/utils"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/appvia/terraform-controller/pkg/utils"
 )
 
 func TestJobTemplateParsable(t *testing.T) {

--- a/pkg/handlers/configurations/validation.go
+++ b/pkg/handlers/configurations/validation.go
@@ -126,7 +126,7 @@ func validateProvider(ctx context.Context, cc client.Client, configuration *terr
 }
 
 // validateModuleConstriants evaluates the module constraints and ensure the configuration passes all policies
-func validateModuleConstriants(ctx context.Context, configuration *terraformv1alphav1.Configuration, list *terraformv1alphav1.PolicyList) error {
+func validateModuleConstriants(_ context.Context, configuration *terraformv1alphav1.Configuration, list *terraformv1alphav1.PolicyList) error {
 	var policies []terraformv1alphav1.Policy
 
 	// @step: first we find all policies which contains module constraints

--- a/pkg/handlers/configurations/validation.go
+++ b/pkg/handlers/configurations/validation.go
@@ -19,13 +19,17 @@ package configurations
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	terraformv1alphav1 "github.com/appvia/terraform-controller/pkg/apis/terraform/v1alpha1"
+	"github.com/appvia/terraform-controller/pkg/utils"
+	"github.com/appvia/terraform-controller/pkg/utils/kubernetes"
 )
 
 type validator struct {
@@ -54,6 +58,21 @@ func (v *validator) ValidateDelete(ctx context.Context, obj runtime.Object) erro
 
 // validate is called to ensure the configuration is valid and incline with current policies
 func (v *validator) validate(ctx context.Context, c *terraformv1alphav1.Configuration) error {
+	// @step: let us check the provider
+	switch {
+	case c.Spec.ProviderRef == nil:
+		return errors.New("no spec.providerRef is defined")
+	case c.Spec.ProviderRef.Name == "":
+		return errors.New("spec.providerRef.name is empty")
+	case c.Spec.ProviderRef.Namespace == "":
+		return errors.New("spec.providerRef.namespace is empty")
+	}
+
+	// @step: check the configuration is permitted to use the provider
+	if err := validateProvider(ctx, v.cc, c); err != nil {
+		return err
+	}
+
 	list := &terraformv1alphav1.PolicyList{}
 	if err := v.cc.List(ctx, list); err != nil {
 		return err
@@ -70,8 +89,44 @@ func (v *validator) validate(ctx context.Context, c *terraformv1alphav1.Configur
 	return nil
 }
 
+// validateProvider is called to ensure the configuration is valid and inline with current provider policy
+func validateProvider(ctx context.Context, cc client.Client, configuration *terraformv1alphav1.Configuration) error {
+	provider := &terraformv1alphav1.Provider{}
+	provider.Namespace = configuration.Spec.ProviderRef.Namespace
+	provider.Name = configuration.Spec.ProviderRef.Name
+
+	found, err := kubernetes.GetIfExists(ctx, cc, provider)
+	if err != nil {
+		return err
+	}
+	if !found || provider.Spec.Selector == nil {
+		return nil
+	}
+
+	// @step: grab the namespace of the configuration
+	namespace := &v1.Namespace{}
+	namespace.Name = configuration.Namespace
+	found, err = kubernetes.GetIfExists(ctx, cc, namespace)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return errors.New("configuration namespace was not found")
+	}
+
+	matched, err := utils.IsSelectorMatch(*provider.Spec.Selector, configuration.GetLabels(), namespace.GetLabels())
+	if err != nil {
+		return err
+	}
+	if !matched {
+		return errors.New("configuration has been denied by the provider policy")
+	}
+
+	return nil
+}
+
 // validateModuleConstriants evaluates the module constraints and ensure the configuration passes all policies
-func validateModuleConstriants(_ context.Context, configuration *terraformv1alphav1.Configuration, list *terraformv1alphav1.PolicyList) error {
+func validateModuleConstriants(ctx context.Context, configuration *terraformv1alphav1.Configuration, list *terraformv1alphav1.PolicyList) error {
 	var policies []terraformv1alphav1.Policy
 
 	// @step: first we find all policies which contains module constraints

--- a/pkg/handlers/configurations/validation_test.go
+++ b/pkg/handlers/configurations/validation_test.go
@@ -165,7 +165,7 @@ var _ = Describe("Configuration Validation", func() {
 			})
 		})
 
-		When("provider resource selectors do match", func() {
+		When("provider resource selectors match", func() {
 			BeforeEach(func() {
 				provider := fixtures.NewValidAWSProvider(namespace, name)
 				provider.Spec.Selector = &terraformv1alphav1.Selector{
@@ -183,7 +183,7 @@ var _ = Describe("Configuration Validation", func() {
 				configuration.Labels = map[string]string{"does_match": "true"}
 
 				err := v.ValidateCreate(ctx, configuration)
-				Expect(err).To(HaveOccurred())
+				Expect(err).To(Succeed())
 			})
 
 			It("should allow the update of the configuration", func() {
@@ -191,7 +191,7 @@ var _ = Describe("Configuration Validation", func() {
 				configuration.Labels = map[string]string{"does_match": "true"}
 
 				err := v.ValidateUpdate(ctx, nil, configuration)
-				Expect(err).To(HaveOccurred())
+				Expect(err).To(Succeed())
 			})
 		})
 	})

--- a/pkg/handlers/configurations/validation_test.go
+++ b/pkg/handlers/configurations/validation_test.go
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2022  Appvia Ltd <info@appvia.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package configurations
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	terraformv1alphav1 "github.com/appvia/terraform-controller/pkg/apis/terraform/v1alpha1"
+	"github.com/appvia/terraform-controller/pkg/schema"
+	"github.com/appvia/terraform-controller/test/fixtures"
+)
+
+var _ = Describe("Configuration Validation", func() {
+	ctx := context.Background()
+	var cc client.Client
+	var v *validator
+
+	namespace := "default"
+	name := "aws"
+
+	When("creating a configuration", func() {
+		BeforeEach(func() {
+			cc = fake.NewClientBuilder().WithScheme(schema.GetScheme()).WithRuntimeObjects(fixtures.NewNamespace("default")).Build()
+			v = &validator{cc: cc}
+		})
+
+		When("we have a module constraint", func() {
+			BeforeEach(func() {
+				provider := fixtures.NewValidAWSProvider(namespace, name)
+				policy := fixtures.NewPolicy("block")
+				policy.Spec.Constraints = &terraformv1alphav1.Constraints{}
+				policy.Spec.Constraints.Modules = &terraformv1alphav1.ModuleConstraint{
+					Allowed: []string{"does_not_match"},
+				}
+
+				Expect(cc.Create(ctx, policy)).To(Succeed())
+				Expect(cc.Create(ctx, provider)).To(Succeed())
+			})
+
+			It("should deny the configuration of the module", func() {
+				err := v.ValidateCreate(ctx, fixtures.NewValidBucketConfiguration(namespace, "test"))
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("the configuration has been denied by policy"))
+			})
+		})
+
+		When("no module constraint passes", func() {
+			BeforeEach(func() {
+				provider := fixtures.NewValidAWSProvider(namespace, name)
+				policy := fixtures.NewPolicy("block")
+				policy.Spec.Constraints = &terraformv1alphav1.Constraints{}
+				policy.Spec.Constraints.Modules = &terraformv1alphav1.ModuleConstraint{
+					Allowed: []string{".*"},
+				}
+
+				Expect(cc.Create(ctx, policy)).To(Succeed())
+				Expect(cc.Create(ctx, provider)).To(Succeed())
+			})
+
+			It("should allow the configuration of the module", func() {
+				err := v.ValidateCreate(ctx, fixtures.NewValidBucketConfiguration(namespace, "test"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should allow the configuration of the module", func() {
+				err := v.ValidateUpdate(ctx, nil, fixtures.NewValidBucketConfiguration(namespace, "test"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		When("provider namespace selectors do not match", func() {
+			BeforeEach(func() {
+				provider := fixtures.NewValidAWSProvider(namespace, name)
+				provider.Spec.Selector = &terraformv1alphav1.Selector{
+					Namespace: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"does_not_match": "true",
+						},
+					},
+				}
+				Expect(cc.Create(ctx, provider)).To(Succeed())
+			})
+
+			It("should deny the creation of the configuration", func() {
+				err := v.ValidateCreate(ctx, fixtures.NewValidBucketConfiguration(namespace, "test"))
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("configuration has been denied by the provider policy"))
+			})
+
+			It("should deny the update of the configuration", func() {
+				err := v.ValidateUpdate(ctx, nil, fixtures.NewValidBucketConfiguration(namespace, "test"))
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("configuration has been denied by the provider policy"))
+			})
+		})
+
+		When("provider namespace selectors do match", func() {
+			BeforeEach(func() {
+				provider := fixtures.NewValidAWSProvider(namespace, name)
+				provider.Spec.Selector = &terraformv1alphav1.Selector{
+					Namespace: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"name": namespace,
+						},
+					},
+				}
+				Expect(cc.Create(ctx, provider)).To(Succeed())
+			})
+
+			It("should allow the creation of the configuration", func() {
+				err := v.ValidateCreate(ctx, fixtures.NewValidBucketConfiguration(namespace, "test"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should allow the update of the configuration", func() {
+				err := v.ValidateUpdate(ctx, nil, fixtures.NewValidBucketConfiguration(namespace, "test"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		When("provider resource selectors do not match", func() {
+			BeforeEach(func() {
+				provider := fixtures.NewValidAWSProvider(namespace, name)
+				provider.Spec.Selector = &terraformv1alphav1.Selector{
+					Resource: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"does_not_match": "true",
+						},
+					},
+				}
+				Expect(cc.Create(ctx, provider)).To(Succeed())
+			})
+
+			It("should deny the creation of the configuration", func() {
+				err := v.ValidateCreate(ctx, fixtures.NewValidBucketConfiguration(namespace, "test"))
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("configuration has been denied by the provider policy"))
+			})
+
+			It("should deny the update of the configuration", func() {
+				err := v.ValidateUpdate(ctx, nil, fixtures.NewValidBucketConfiguration(namespace, "test"))
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("configuration has been denied by the provider policy"))
+			})
+		})
+
+		When("provider resource selectors do match", func() {
+			BeforeEach(func() {
+				provider := fixtures.NewValidAWSProvider(namespace, name)
+				provider.Spec.Selector = &terraformv1alphav1.Selector{
+					Resource: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"does_match": "true",
+						},
+					},
+				}
+				Expect(cc.Create(ctx, provider)).To(Succeed())
+			})
+
+			It("should allow the creation of the configuration", func() {
+				configuration := fixtures.NewValidBucketConfiguration(namespace, "test")
+				configuration.Labels = map[string]string{"does_match": "true"}
+
+				err := v.ValidateCreate(ctx, configuration)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should allow the update of the configuration", func() {
+				configuration := fixtures.NewValidBucketConfiguration(namespace, "test")
+				configuration.Labels = map[string]string{"does_match": "true"}
+
+				err := v.ValidateUpdate(ctx, nil, configuration)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+})

--- a/pkg/handlers/providers/validation_test.go
+++ b/pkg/handlers/providers/validation_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Provider Validation", func() {
 	})
 
 	When("creating a provider with a injected identity", func() {
-		It("should throw error when no sevice account", func() {
+		It("should throw error when no service account", func() {
 			policy := fixtures.NewValidAWSProvider("default", "test")
 			policy.Spec.Source = "injected"
 			policy.Spec.ServiceAccount = nil

--- a/pkg/register/assets.go
+++ b/pkg/register/assets.go
@@ -647,7 +647,7 @@ spec:
                   description: Selector provider the ability to filter who can use this provider. If empty, all users in the cluster is permitted to use the provider. Otherrise you can specify a selector which can use namespace and resource labels
                   properties:
                     namespace:
-                      description: Namespace provides the ability to filter on the namespace
+                      description: Namespace is used to filter a configuration based on the namespace labels of where it exists
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -677,7 +677,7 @@ spec:
                           type: object
                       type: object
                     resource:
-                      description: Resource provides the ability to filter on the resource labels
+                      description: Resource provides the ability to filter a configuration based on it's labels
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.

--- a/pkg/register/assets.go
+++ b/pkg/register/assets.go
@@ -643,6 +643,70 @@ spec:
                       description: Namespace defines the space within which the secret name must be unique.
                       type: string
                   type: object
+                selector:
+                  description: Selector provider the ability to filter who can use this provider. If empty, all users in the cluster is permitted to use the provider. Otherrise you can specify a selector which can use namespace and resource labels
+                  properties:
+                    namespace:
+                      description: Namespace provides the ability to filter on the namespace
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    resource:
+                      description: Resource provides the ability to filter on the resource labels
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                  type: object
                 serviceAccount:
                   description: ServiceAccount is the name of a service account to use when the provider source is 'injected'. The service account should exist in the terraform controller namespace and be configure per cloud vendor requirements for pod identity.
                   type: string

--- a/pkg/utils/labels.go
+++ b/pkg/utils/labels.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2022  Appvia Ltd <info@appvia.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package utils
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	terraformv1alphav1 "github.com/appvia/terraform-controller/pkg/apis/terraform/v1alpha1"
+)
+
+// IsSelectorMatch is used to check if the resource matches the selectors.
+func IsSelectorMatch(
+	selector terraformv1alphav1.Selector,
+	resourceLabels, namespaceLabels map[string]string) (bool, error) {
+
+	if selector.Namespace == nil && selector.Resource == nil {
+		return true, nil
+	}
+
+	if selector.Namespace != nil {
+		match, err := IsLabelSelectorMatch(namespaceLabels, *selector.Namespace)
+		if err != nil {
+			return false, err
+		}
+		if !match {
+
+			return false, nil
+		}
+	}
+
+	if selector.Resource != nil {
+		return IsLabelSelectorMatch(resourceLabels, *selector.Resource)
+	}
+
+	return true, nil
+}
+
+// IsLabelSelectorMatch is used to check if the selectors matches the labels.
+func IsLabelSelectorMatch(source map[string]string, selector metav1.LabelSelector) (bool, error) {
+	matcher, err := metav1.LabelSelectorAsSelector(&selector)
+	if err != nil {
+		return false, err
+	}
+	if matcher.Empty() {
+		return false, nil
+	}
+
+	return matcher.Matches(labels.Set(source)), nil
+}

--- a/pkg/utils/labels_test.go
+++ b/pkg/utils/labels_test.go
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2022  Appvia Ltd <info@appvia.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	terraformv1alphav1 "github.com/appvia/terraform-controller/pkg/apis/terraform/v1alpha1"
+)
+
+func TestIsSelectorMatch(t *testing.T) {
+	cases := []struct {
+		ResourceLabels map[string]string
+		NamespaceLabel map[string]string
+		Selector       terraformv1alphav1.Selector
+		Expect         bool
+	}{
+		{
+			Expect: true,
+		},
+		{
+			Expect: true,
+			Selector: terraformv1alphav1.Selector{
+				Namespace: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"is": "there"},
+				},
+			},
+			NamespaceLabel: map[string]string{"is": "there"},
+		},
+		{
+			Expect: false,
+			Selector: terraformv1alphav1.Selector{
+				Namespace: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"not": "there"},
+				},
+			},
+			NamespaceLabel: map[string]string{"is": "there"},
+		},
+		{
+			Expect: false,
+			Selector: terraformv1alphav1.Selector{
+				Namespace: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "not_there",
+							Operator: metav1.LabelSelectorOpExists,
+						},
+					},
+				},
+			},
+			NamespaceLabel: map[string]string{"is": "there"},
+		},
+		{
+			Expect: true,
+			Selector: terraformv1alphav1.Selector{
+				Namespace: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "is",
+							Operator: metav1.LabelSelectorOpExists,
+						},
+					},
+				},
+			},
+			NamespaceLabel: map[string]string{"is": "there"},
+		},
+		{
+			Expect: false,
+			Selector: terraformv1alphav1.Selector{
+				Resource: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "is",
+							Operator: metav1.LabelSelectorOpExists,
+						},
+					},
+				},
+			},
+			ResourceLabels: map[string]string{"not": "there"},
+		},
+		{
+			Expect: true,
+			Selector: terraformv1alphav1.Selector{
+				Resource: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "is",
+							Operator: metav1.LabelSelectorOpExists,
+						},
+					},
+				},
+			},
+			ResourceLabels: map[string]string{"is": "there"},
+		},
+	}
+
+	for _, c := range cases {
+		match, err := IsSelectorMatch(c.Selector, c.ResourceLabels, c.NamespaceLabel)
+		assert.NoError(t, err)
+		assert.Equal(t, c.Expect, match)
+	}
+}
+
+func TestIsLabelSelectorMatch(t *testing.T) {
+	cases := []struct {
+		Labels   map[string]string
+		Selector metav1.LabelSelector
+		Expect   bool
+	}{
+		{
+			Labels:   map[string]string{"is": "empty"},
+			Selector: metav1.LabelSelector{},
+			Expect:   false,
+		},
+		{
+			Labels: map[string]string{"is": "there"},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"is": "there"},
+			},
+			Expect: true,
+		},
+		{
+			Labels: map[string]string{"is": "there"},
+			Selector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "is",
+						Operator: metav1.LabelSelectorOpExists,
+					},
+				},
+			},
+			Expect: true,
+		},
+		{
+			Labels: map[string]string{"is": "there"},
+			Selector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "is",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"there"},
+					},
+				},
+			},
+			Expect: true,
+		},
+	}
+
+	for _, c := range cases {
+		match, err := IsLabelSelectorMatch(c.Labels, c.Selector)
+		assert.NoError(t, err)
+		assert.Equal(t, c.Expect, match)
+	}
+}


### PR DESCRIPTION
The support adds the support to control who can access providers based on namespace and resource labelling

The provider now have a `spec.selector` which can specify namespace and resource labels selectors. These are checks against the requesting configuration and if they don't matched, the request to use the provider is denied.

```yaml
  ---
  apiVersion: terraform.appvia.io/v1alpha1
  kind: Provider
  metadata:
   name: default-irsa
  spec:
    selector:
      # duplicate the labels just to show we support both
      namespace:
        matchLabel:
          name: apps
        matchExpressions:
          - key: name
            operator: In
            values: [apps]
    serviceAccount: terraform-executor
    source: injected
    provider: aws
```

289f936 [FEATURE] Provider RBAC
c5cc9b2 - updating the controller to check the provider rbac is sounds
841c44d - adding a handler to check the configuration crd and provider rbac
38fb4a1 - adding the unit checks
8714b4f - fixing up the unit tests on the handler

Fixed Issue #27 