### PR TITLE
[BUGFIX] - Provider Service Accounts

### DIFF
--- a/pkg/assets/assets_test.go
+++ b/pkg/assets/assets_test.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022  Appvia Ltd <info@appvia.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package assets
+
+import (
+	"html/template"
+	"testing"
+
+	"github.com/appvia/terraform-controller/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJobTemplateParsable(t *testing.T) {
+	tl, err := Asset("job.yaml.tpl")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, tl)
+
+	tpl, err := template.New("main").Funcs(utils.GetTxtFunc()).Parse(string(tl))
+	assert.NoError(t, err)
+	assert.NotNil(t, tpl)
+}
+
+func TestAssetNames(t *testing.T) {
+	assert.Equal(t, []string{"job.yaml.tpl"}, AssetNames())
+}
+
+func TestAsset(t *testing.T) {
+	b, err := Asset("job.yaml.tpl")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, b)
+
+	b, err = Asset("not_there")
+	assert.Error(t, err)
+	assert.Empty(t, b)
+}
+
+func TestMustAssetNotThere(t *testing.T) {
+	defer func() {
+		assert.NotNil(t, recover())
+	}()
+	MustAsset("not_there")
+}
+
+func TestMustAsset(t *testing.T) {
+	assert.NotEmpty(t, MustAsset("job.yaml.tpl"))
+}

--- a/pkg/assets/job.yaml.tpl
+++ b/pkg/assets/job.yaml.tpl
@@ -15,7 +15,11 @@ spec:
   template:
     spec:
       restartPolicy: OnFailure
+      {{- if eq .Provider.Source "injected" }}
+      serviceAccountName: {{ .Provider.ServiceAccount }}
+      {{- else }}
       serviceAccountName: {{ .ServiceAccount }}
+      {{- end }}
       securityContext:
         runAsUser: 65534
         runAsGroup: 65534

--- a/pkg/controller/configuration/delete.go
+++ b/pkg/controller/configuration/delete.go
@@ -73,14 +73,14 @@ func (c *Controller) ensureTerraformDestroy(configuration *terraformv1alphav1.Co
 		// @step: generate the destroy job
 		batch := jobs.New(configuration, state.provider)
 		runner, err := batch.NewTerraformDestroy(jobs.Options{
-			EnableInfraCosts: c.EnableInfracosts,
-			ExecutorImage:    c.ExecutorImage,
-			InfracostsImage:  c.InfracostsImage,
-			InfracostsSecret: c.InfracostsSecretName,
-			Namespace:        c.JobNamespace,
-			ServiceAccount:   "terraform-controller",
-			Template:         state.jobTemplate,
-			TerraformImage:   GetTerraformImage(configuration, c.TerraformImage),
+			DefaultServiceAccount: "terraform-executor",
+			EnableInfraCosts:      c.EnableInfracosts,
+			ExecutorImage:         c.ExecutorImage,
+			InfracostsImage:       c.InfracostsImage,
+			InfracostsSecret:      c.InfracostsSecretName,
+			Namespace:             c.JobNamespace,
+			Template:              state.jobTemplate,
+			TerraformImage:        GetTerraformImage(configuration, c.TerraformImage),
 		})
 		if err != nil {
 			cond.Failed(err, "Failed to create the terraform destroy job")

--- a/pkg/controller/configuration/ensure.go
+++ b/pkg/controller/configuration/ensure.go
@@ -357,16 +357,16 @@ func (c *Controller) ensureTerraformPlan(configuration *terraformv1alphav1.Confi
 
 		// @step: lets build the options to render the job
 		options := jobs.Options{
-			EnableInfraCosts: c.EnableInfracosts,
-			ExecutorImage:    c.ExecutorImage,
-			InfracostsImage:  c.InfracostsImage,
-			InfracostsSecret: c.InfracostsSecretName,
-			Namespace:        c.JobNamespace,
-			PolicyImage:      c.PolicyImage,
-			PolicyConstraint: policy,
-			ServiceAccount:   "terraform-controller",
-			Template:         state.jobTemplate,
-			TerraformImage:   GetTerraformImage(configuration, c.TerraformImage),
+			DefaultServiceAccount: "terraform-executor",
+			EnableInfraCosts:      c.EnableInfracosts,
+			ExecutorImage:         c.ExecutorImage,
+			InfracostsImage:       c.InfracostsImage,
+			InfracostsSecret:      c.InfracostsSecretName,
+			Namespace:             c.JobNamespace,
+			PolicyImage:           c.PolicyImage,
+			PolicyConstraint:      policy,
+			Template:              state.jobTemplate,
+			TerraformImage:        GetTerraformImage(configuration, c.TerraformImage),
 		}
 
 		// @step: use the options to generate the job
@@ -567,14 +567,14 @@ func (c *Controller) ensureTerraformApply(configuration *terraformv1alphav1.Conf
 
 		// @step: create the terraform job
 		runner, err := jobs.New(configuration, state.provider).NewTerraformApply(jobs.Options{
-			EnableInfraCosts: c.EnableInfracosts,
-			ExecutorImage:    c.ExecutorImage,
-			InfracostsImage:  c.InfracostsImage,
-			InfracostsSecret: c.InfracostsSecretName,
-			Namespace:        c.JobNamespace,
-			ServiceAccount:   "terraform-controller",
-			Template:         state.jobTemplate,
-			TerraformImage:   GetTerraformImage(configuration, c.TerraformImage),
+			DefaultServiceAccount: "terraform-executor",
+			EnableInfraCosts:      c.EnableInfracosts,
+			ExecutorImage:         c.ExecutorImage,
+			InfracostsImage:       c.InfracostsImage,
+			InfracostsSecret:      c.InfracostsSecretName,
+			Namespace:             c.JobNamespace,
+			Template:              state.jobTemplate,
+			TerraformImage:        GetTerraformImage(configuration, c.TerraformImage),
 		})
 		if err != nil {
 			cond.Failed(err, "Failed to create the terraform apply job")

--- a/pkg/utils/jobs/jobs.go
+++ b/pkg/utils/jobs/jobs.go
@@ -36,6 +36,8 @@ import (
 
 // Options is the configuration for the render
 type Options struct {
+	// DefaultServiceAccount is the name of the service account to run the jobs under
+	DefaultServiceAccount string
 	// EnableInfraCosts is the flag to enable cost analysis
 	EnableInfraCosts bool
 	// ExecutorImage is the image to use for the terraform jobs
@@ -50,8 +52,6 @@ type Options struct {
 	PolicyConstraint *terraformv1alphav1.PolicyConstraint
 	// PolicyImage is image to use for checkov
 	PolicyImage string
-	// ServiceAccount is the name of the service account to run the jobs under
-	ServiceAccount string
 	// Template is the source for the job template if overridden by the controller
 	Template []byte
 	// TerraformImage is the image to use for the terraform jobs
@@ -181,7 +181,7 @@ func (r *Render) createTerraformFromTemplate(options Options, stage string) (*ba
 		"EnableVariables":    r.configuration.HasVariables(),
 		"ImagePullPolicy":    "IfNotPresent",
 		"Policy":             options.PolicyConstraint,
-		"ServiceAccount":     options.ServiceAccount,
+		"ServiceAccount":     options.DefaultServiceAccount,
 		"Stage":              stage,
 		"TerraformArguments": arguments,
 		"Configuration": map[string]interface{}{


### PR DESCRIPTION
We were not correctly retrieving the service account from the provider and was incorrectly choosing the service account.

- Defaulting the service account to the terraform-executor
- Using the provider service account is defined and source injected
- Added unit tests to ensure it doesn't happen again
- Added checks on the job template and assets