### PR TITLE
[BUGFIX] - Provider Enum on API Types

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   e2e:
-    uses: appvia/terraform-controller/.github/workflows/e2e.yaml
+    uses: appvia/terraform-controller/.github/workflows/e2e.yaml@master
 
   release:
     needs: e2e

--- a/charts/crds/terraform.appvia.io_providers.yaml
+++ b/charts/crds/terraform.appvia.io_providers.yaml
@@ -44,10 +44,6 @@ spec:
               properties:
                 provider:
                   description: ProviderType defines the cloud provider which is being used, currently supported providers are aws, google or azurerm.
-                  enum:
-                    - aws
-                    - gcp
-                    - azure
                   type: string
                 secretRef:
                   description: 'SecretRef is a reference to a kubernetes secret. This is required only when using the source: secret. The secret should include the environment variables required to by the terraform provider.'

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -26,9 +26,9 @@ controller:
     # policy is image for policy (wip)
     policy: bridgecrew/checkov:2.0.1143
     # is the controller image
-    controller: quay.io/appvia/terraform-controller:v0.1.2
+    controller: quay.io/appvia/terraform-controller:v0.1.3
     # The terraform image used when running jobs
-    executor: quay.io/appvia/terraform-executor:v0.1.2
+    executor: quay.io/appvia/terraform-executor:v0.1.3
 
   # Allows you to overload the templates
   templates:

--- a/pkg/apis/terraform/v1alpha1/provider_types.go
+++ b/pkg/apis/terraform/v1alpha1/provider_types.go
@@ -64,7 +64,6 @@ type ProviderSpec struct {
 	// ProviderType defines the cloud provider which is being used, currently supported providers are
 	// aws, google or azurerm.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=aws;gcp;azure
 	Provider ProviderType `json:"provider"`
 	// Source defines the type of credentials the provider is wrapper, this could be wrapping a static secret
 	// or using a managed identity. The currently supported values are secret and injected.

--- a/pkg/register/assets.go
+++ b/pkg/register/assets.go
@@ -628,10 +628,6 @@ spec:
               properties:
                 provider:
                   description: ProviderType defines the cloud provider which is being used, currently supported providers are aws, google or azurerm.
-                  enum:
-                    - aws
-                    - gcp
-                    - azure
                   type: string
                 secretRef:
                   description: 'SecretRef is a reference to a kubernetes secret. This is required only when using the source: secret. The secret should include the environment variables required to by the terraform provider.'


### PR DESCRIPTION
Fixing a silly mistake found from the e2e ticket