### PR TITLE
[BUILD] - Latest Workflow Change

### DIFF
--- a/.github/workflows/latest.yaml
+++ b/.github/workflows/latest.yaml
@@ -31,7 +31,6 @@ jobs:
         run: make release-images
 
   release-helm:
-    needs: release-images
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
The helm release job doesn't need to wait on the release images as they are not connected