### PR TITLE
[API] - Description on API Types

### DIFF
--- a/charts/terraform-controller/crds/terraform.appvia.io_policies.yaml
+++ b/charts/terraform-controller/crds/terraform.appvia.io_policies.yaml
@@ -48,7 +48,7 @@ spec:
                             type: string
                           type: array
                         external:
-                          description: External is a collection of external checks which should be included in the scan. Each of the external sources and retrieved and sourced into /run/policy/<NAME> where they can be included as part of the scan
+                          description: External is a collection of external checks which should be included in the scan. Each of the external sources and retrieved and sourced into /run/policy/NAME where they can be included as part of the scan
                           items:
                             description: ExternalCheck defines the definition for an external check - this comprises of the source and any optional secret
                             properties:

--- a/pkg/apis/terraform/v1alpha1/constraint_types.go
+++ b/pkg/apis/terraform/v1alpha1/constraint_types.go
@@ -71,7 +71,7 @@ type PolicyConstraint struct {
 	// +kubebuilder:validation:Optional
 	Checks []string `json:"checks,omitempty"`
 	// External is a collection of external checks which should be included in the scan. Each
-	// of the external sources and retrieved and sourced into /run/policy/<NAME> where they can
+	// of the external sources and retrieved and sourced into /run/policy/NAME where they can
 	// be included as part of the scan
 	// +kubebuilder:validation:Optional
 	External []ExternalCheck `json:"external,omitempty"`

--- a/pkg/register/assets.go
+++ b/pkg/register/assets.go
@@ -349,7 +349,7 @@ spec:
                             type: string
                           type: array
                         external:
-                          description: External is a collection of external checks which should be included in the scan. Each of the external sources and retrieved and sourced into /run/policy/<NAME> where they can be included as part of the scan
+                          description: External is a collection of external checks which should be included in the scan. Each of the external sources and retrieved and sourced into /run/policy/NAME where they can be included as part of the scan
                           items:
                             description: ExternalCheck defines the definition for an external check - this comprises of the source and any optional secret
                             properties:


### PR DESCRIPTION
The <NAME> is causing an error when generating the api reference documentation; it's not really required so we can drop it