### PR TITLE
Fix linting timeout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          args: --timeout 2m
+          args: --timeout 4m
 
   helm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The timeout on linting currently set to 2m is occasionally hitting the
limit and causing failed runs. Bumping the timeout to 4 minutes.