### PR TITLE
[FEATURE] - Adding Terraform Version to Status

### DIFF
--- a/pkg/apis/terraform/v1alpha1/configuration_types.go
+++ b/pkg/apis/terraform/v1alpha1/configuration_types.go
@@ -221,6 +221,10 @@ type ConfigurationStatus struct {
 	// This field is taken from the terraform state itself.
 	// +kubebuilder:validation:Optional
 	Resources int `json:"resources,omitempty"`
+	// TerraformVersion is the version of terraform which was last used to run this
+	// configuration
+	// +kubebuilder:validation:Optional
+	TerraformVersion string `json:"terraformVersion,omitempty"`
 }
 
 // GetNamespacedName returns the namespaced resource type

--- a/pkg/apis/terraform/v1alpha1/configuration_types.go
+++ b/pkg/apis/terraform/v1alpha1/configuration_types.go
@@ -44,6 +44,11 @@ const (
 )
 
 const (
+	// TerraformStateSecretKey is the key used by the terraform state secret
+	TerraformStateSecretKey = "tfstate"
+)
+
+const (
 	// CheckovJobTemplateConfigMapKey is the key name for the job template in the configmap
 	CheckovJobTemplateConfigMapKey = "checkov.yaml"
 	// TerraformBackendConfigMapKey is the key name for the terraform backend in the configmap

--- a/pkg/controller/configuration/ensure.go
+++ b/pkg/controller/configuration/ensure.go
@@ -814,7 +814,7 @@ func (c *Controller) ensureConnectionSecret(configuration *terraformv1alphav1.Co
 		}
 
 		// @step: decode the terraform state (essentially just returning the uncompressed content)
-		state, err := terraform.DecodeState(ss.Data["tfstate"])
+		state, err := terraform.DecodeState(ss.Data[terraformv1alphav1.TerraformStateSecretKey])
 		if err != nil {
 			cond.Failed(err, "Failed to decode the terraform state")
 

--- a/pkg/controller/configuration/ensure.go
+++ b/pkg/controller/configuration/ensure.go
@@ -777,6 +777,7 @@ func (c *Controller) ensureTerraformStatus(configuration *terraformv1alphav1.Con
 		}
 
 		configuration.Status.Resources = state.CountResources()
+		configuration.Status.TerraformVersion = state.TerraformVersion
 
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controller/configuration/reconcile_test.go
+++ b/pkg/controller/configuration/reconcile_test.go
@@ -1373,4 +1373,86 @@ terraform {
 			Expect(rerr).To(BeNil())
 		})
 	})
+
+	When("terraform apply has been provisioned", func() {
+		BeforeEach(func() {
+			configuration = fixtures.NewValidBucketConfiguration(cfgNamespace, "bucket")
+			// create two successful jobs
+			plan := fixtures.NewTerraformJob(configuration, ctrl.JobNamespace, terraformv1alphav1.StageTerraformPlan)
+			plan.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: v1.ConditionTrue}}
+			plan.Status.Succeeded = 1
+
+			apply := fixtures.NewTerraformJob(configuration, ctrl.JobNamespace, terraformv1alphav1.StageTerraformApply)
+			apply.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: v1.ConditionTrue}}
+			apply.Status.Succeeded = 1
+
+			// create a fake terraform state
+			state := fixtures.NewTerraformState(configuration)
+			state.Namespace = "default"
+
+			Setup(configuration, plan, apply, state)
+		})
+
+		When("costs and policy is not enabled", func() {
+			BeforeEach(func() {
+				result, _, rerr = controllertests.Roll(context.TODO(), ctrl, configuration, 3)
+			})
+
+			It("should have the conditions", func() {
+				Expect(cc.Get(context.TODO(), configuration.GetNamespacedName(), configuration)).ToNot(HaveOccurred())
+				Expect(configuration.Status.Conditions).To(HaveLen(defaultConditions))
+			})
+
+			It("should indicate the terraform apply has run", func() {
+				Expect(cc.Get(context.TODO(), configuration.GetNamespacedName(), configuration)).ToNot(HaveOccurred())
+
+				cond := configuration.Status.GetCondition(terraformv1alphav1.ConditionTerraformApply)
+				Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+				Expect(cond.Reason).To(Equal(corev1alphav1.ReasonReady))
+				Expect(cond.Message).To(Equal("Terraform apply is complete"))
+			})
+
+			It("should a last reconcilation time on the status", func() {
+				Expect(cc.Get(context.TODO(), configuration.GetNamespacedName(), configuration)).ToNot(HaveOccurred())
+
+				Expect(configuration.Status.LastReconcile).ToNot(BeNil())
+				Expect(configuration.Status.LastReconcile.Time).ToNot(BeNil())
+				Expect(configuration.Status.LastReconcile.Generation).To(Equal(int64(0)))
+			})
+
+			It("should a last success reconcilation time on the status", func() {
+				Expect(cc.Get(context.TODO(), configuration.GetNamespacedName(), configuration)).ToNot(HaveOccurred())
+
+				Expect(configuration.Status.LastSuccess).ToNot(BeNil())
+				Expect(configuration.Status.LastSuccess.Time).ToNot(BeNil())
+				Expect(configuration.Status.LastSuccess.Generation).To(Equal(int64(0)))
+			})
+
+			It("should have a version on status", func() {
+				Expect(cc.Get(context.TODO(), configuration.GetNamespacedName(), configuration)).ToNot(HaveOccurred())
+				// note this is a constant in the fixtures
+				Expect(configuration.Status.TerraformVersion).To(Equal("1.1.9"))
+			})
+
+			It("should have a resource count on the status", func() {
+				Expect(cc.Get(context.TODO(), configuration.GetNamespacedName(), configuration)).ToNot(HaveOccurred())
+				Expect(configuration.Status.Resources).To(Equal(1))
+			})
+
+			It("should have created a secret containing the module output", func() {
+				Expect(cc.Get(context.TODO(), configuration.GetNamespacedName(), configuration)).ToNot(HaveOccurred())
+
+				secret := &v1.Secret{}
+				secret.Name = configuration.Spec.WriteConnectionSecretToRef.Name
+				secret.Namespace = configuration.Namespace
+
+				found, err := kubernetes.GetIfExists(context.TODO(), cc, secret)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+				Expect(secret.Data).ToNot(BeNil())
+				Expect(secret.Data).To(HaveKey("TEST_OUTPUT"))
+				Expect(secret.Data["TEST_OUTPUT"]).To(Equal("test"))
+			})
+		})
+	})
 })

--- a/pkg/controller/configuration/reconcile_test.go
+++ b/pkg/controller/configuration/reconcile_test.go
@@ -1451,7 +1451,7 @@ terraform {
 				Expect(found).To(BeTrue())
 				Expect(secret.Data).ToNot(BeNil())
 				Expect(secret.Data).To(HaveKey("TEST_OUTPUT"))
-				Expect(secret.Data["TEST_OUTPUT"]).To(Equal("test"))
+				Expect(secret.Data["TEST_OUTPUT"]).To(Equal([]byte("test")))
 			})
 		})
 	})

--- a/test/e2e/integration/apply.bats
+++ b/test/e2e/integration/apply.bats
@@ -65,3 +65,8 @@ teardown() {
   runit "kubectl -n ${APP_NAMESPACE} logs ${POD} 2>&1" "grep -q '\[build\] completed'"
   [[ "$status" -eq 0 ]]
 }
+
+@test "We should have the terraform version on the status" {
+  runit "kubectl -n ${APP_NAMESPACE} get configuration ${RESOURCE_NAME} -o json" "jq -r '.status.terraformVersion' | grep -q '[0-9]\+\.[0-9]\+\.[0-9]\+'"
+  [[ "$status" -eq 0 ]]
+}

--- a/test/fixtures/state.go
+++ b/test/fixtures/state.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2022  Appvia Ltd <info@appvia.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fixtures
+
+import (
+	"bytes"
+	"compress/gzip"
+
+	terraformv1alphav1 "github.com/appvia/terraform-controller/pkg/apis/terraform/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+)
+
+var state = `
+{
+	"terraform_version": "1.1.9",
+	"resources": [
+		{
+			"mode": "managed",
+			"type" : "aws_instance",
+			"instances": [
+				{
+					"id": "i-0f9c9f9c9f9c9f9c9",
+					"name": "foo"
+				}
+			]
+		}
+	],
+	"outputs": {
+		"test_output": {
+			"value": "test",
+			"type": "string"
+		}
+	}
+}
+`
+
+// NewTerraformState returns a fake state
+func NewTerraformState(configuration *terraformv1alphav1.Configuration) *v1.Secret {
+	encoded := &bytes.Buffer{}
+
+	w := gzip.NewWriter(encoded)
+	//nolint:errcheck
+	w.Write([]byte(state))
+	w.Close()
+
+	secret := &v1.Secret{}
+	secret.Name = configuration.GetTerraformStateSecretName()
+	secret.Data = map[string][]byte{
+		terraformv1alphav1.TerraformStateSecretKey: encoded.Bytes(),
+	}
+
+	return secret
+}


### PR DESCRIPTION
Currently the terraform version is not exposed to the developers so
though they can override the version they would have to ask the platform
team or view the logs to know the version. With this PR the version of
terraform is applied to the status