### PR TITLE
[E2E] - Deployment Key Secret

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -108,4 +108,5 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.E2E_AWS_ACCESS_KEY_ID }}
           AWS_REGION: ${{ secrets.E2E_AWS_REGION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.E2E_AWS_SECRET_ACCESS_KEY }}
+          E2E_SSH_DEPLOYMENT_KEY: ${{ secrets.E2E_SSH_DEPLOYMENT_KEY }}
           INFRACOST_API_KEY: ${{ secrets.INFRACOST_API_KEY }}


### PR DESCRIPTION
Adding the deployment key secret to the e2e list, this is used to verify private repositories
