### PR TITLE
[BUGFIX] - Streaming Logs

### DIFF
--- a/pkg/apiserver/server_test.go
+++ b/pkg/apiserver/server_test.go
@@ -37,5 +37,5 @@ func TestHealthHandler(t *testing.T) {
 
 	svc.handleHealth(w, req)
 	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
-	assert.Equal(t, "OK", w.Body.String())
+	assert.Equal(t, "OK\n", w.Body.String())
 }


### PR DESCRIPTION
Currently the pods used to watch the execution logs in the developer namespace can be a little slow,. This is due to the http.ResponseWriter buffering the output. With this PR we check for a http.Flusher interface and flush the logs line by line, making the feedback quickier. This is especially useful on long running configurations such as those for RDS's
