### PR TITLE
[HELM] - Service Account Permissions - Executors

### DIFF
--- a/charts/terraform-controller/templates/rbac.yaml
+++ b/charts/terraform-controller/templates/rbac.yaml
@@ -177,7 +177,13 @@ roleRef:
   kind: Role
   name: {{ include "terraform-controller.fullname" . }}-executor
 subjects:
+  {{- if .Values.rbac.enableExecutorServiceAccountPermissions }}
+  - kind: Group
+    name: system:serviceaccounts:{{ .Release.Namespace }}
+    apiGroup: rbac.authorization.k8s.io
+  {{- else }}
   - kind: ServiceAccount
     name: terraform-executor
     namespace: {{ .Release.Namespace }}
+  {{- end }}
 {{- end }}

--- a/charts/terraform-controller/values.yaml
+++ b/charts/terraform-controller/values.yaml
@@ -100,6 +100,11 @@ securityContext:
       - all
 
 rbac:
+  # Indicates we allow all service account in the controller namespace the role of
+  # executor. This makes rolling out multiple providers backed to multiple services easier.
+  # Service account used by executors need access to read and write secrets and leases in the
+  # controller namespace (namely the controller-executor role)
+  enableExecutorServiceAccountPermissions: false
   # Indicates we should create all the rbac
   create: true
   # service account for the controller


### PR DESCRIPTION
We should allow the service account in the controller namespace permissions to run as executors, this makes the ability to deploy multiple service account easier

By default all service account used by an executor (i.e lets assume you want to use multiple injected identities) need RBAC permissions to lease and secrets in the controller namespace i.e. 

```yaml
  ---
  apiVersion: rbac.authorization.k8s.io/v1
  kind: Role
  metadata:
    name: {{ include "terraform-controller.fullname" . }}-executor
  rules:
    - apiGroups:
        - coordination.k8s.io
      resources:
        - leases
      verbs:
        - create
        - delete
        - get
        - list
        - update
        - watch
    - apiGroups:
        - ""
      resources:
       - configmaps
      verbs:
        - get
        - list
        - watch
    - apiGroups:
        - ""
      resources:
        - secrets
      verbs:
        - create
        - delete
        - get
        - list
        - patch
        - update
        - watch
```

If you create multiple provider you need to ensure the service account has these permissions as terraform is using `kubernetes` as a state backend and it requires these permissions to operator. By enabling `rbac.enableExecutorServiceAccountPermissions` in the helm chart the the binding is changed to apply to `all` service account in the controller namespace

```yaml 
  - kind: Group
    name: system:serviceaccounts:{{ .Release.Namespace }}
    apiGroup: rbac.authorization.k8s.io
```

Note this is not a requirement - just a convenience - as without it the platform it responsible for making sure the service accoutn has the correct permissions 

