### PR TITLE
[HELM] - Deploy Providers via Helm

### DIFF
--- a/charts/terraform-controller/templates/providers.yaml
+++ b/charts/terraform-controller/templates/providers.yaml
@@ -1,22 +1,30 @@
-{{- range .Value.providers }}
+{{ $namespace := .Release.Namespace }}
+{{- range $index, $provider := .Values.providers }}
+{{- $cloud := $provider.provider | required (printf ".Values.providers[%d].provider is required." $index) -}}
+{{- $name := $provider.name | required (printf ".Values.providers[%d].name is required." $index) -}}
+{{- $source := $provider.source | required (printf ".Values.providers[%d].source is required." $index) -}}
 ---
 apiVersion: terraform.appvia.io/v1alpha1
 kind: Provider
 metadata:
-  name: {{ .name }}
+  name: {{ $name }}
   annotations:
-    {{- .annotations | nindent 4 }}
+    {{- range $key, $value := $provider.annotations }}
+    {{ $key }}: "{{ $value }}"
+    {{- end }}
   labels:
-    {{- .labels | nindent 4 }}
+    {{- range $key, $value := $provider.labels }}
+    {{ $key }}: "{{ $value }}"
+    {{- end }}
 spec:
-  source: {{ .source }}
-  provider: {{ .cloud }}
-  {{- if eq .source "secret" }}
+  source: {{ $source }}
+  provider: {{ $cloud }}
+  {{- if eq $provider.source "secret" }}
   secretRef:
-    namespace: {{ .Release.Namespace }}
-    name: {{ .secret }}
+    namespace: {{ $namespace }}
+    name: {{ $provider.secret }}
   {{- end }}
-  {{- if eq .source "injected" }}
-  serviceAccount: {{ .serviceAccount }}
+  {{- if eq $provider.source "injected" }}
+  serviceAccount: {{ $provider.serviceAccount }}
   {{- end }}
 {{- end }}

--- a/charts/terraform-controller/templates/providers.yaml
+++ b/charts/terraform-controller/templates/providers.yaml
@@ -1,0 +1,22 @@
+{{- range .Value.providers }}
+---
+apiVersion: terraform.appvia.io/v1alpha1
+kind: Provider
+metadata:
+  name: {{ .name }}
+  annotations:
+    {{- .annotations | nindent 4 }}
+  labels:
+    {{- .labels | nindent 4 }}
+spec:
+  source: {{ .source }}
+  provider: {{ .cloud }}
+  {{- if eq .source "secret" }}
+  secretRef:
+    namespace: {{ .Release.Namespace }}
+    name: {{ .secret }}
+  {{- end }}
+  {{- if eq .source "injected" }}
+  serviceAccount: {{ .serviceAccount }}
+  {{- end }}
+{{- end }}

--- a/charts/terraform-controller/values.yaml
+++ b/charts/terraform-controller/values.yaml
@@ -99,6 +99,19 @@ securityContext:
     drop:
       - all
 
+# Allows to you deploy a number of providers into the clusters
+providers:
+#  - name: aws
+#    source: injected
+#    labels: {}
+#    annotations: {}
+#    # The cloud vendor this credentials is for
+#    provider: aws|google|azurerm
+#    # When using source secret we should have a secret name
+#    secret: NAME
+#    # When using source injected we should have a service account
+#    serviceAccount: SERV
+
 rbac:
   # Indicates we should create all the rbac
   create: true


### PR DESCRIPTION
At present to deploy a provider it must be done out-of-baud from the helm chart. With this PR you can adding a collection of Providers which will deploy along aside the chart

Example for creating and IRSA 

```yaml
---
rbac:
  executor:
    annotations:
      eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ROLE

providers:
  - source: injected
    provider: aws
    serviceAccount: terraform-executor
```
