### PR TITLE
[HELM] - Deploy Policies via Helm Chart

### DIFF
--- a/charts/terraform-controller/templates/policies.yaml
+++ b/charts/terraform-controller/templates/policies.yaml
@@ -1,0 +1,19 @@
+{{- range $i, $o := .Values.policies }}
+{{- $name := $o.name | required (printf ".Values.policies[%d].name is required." $i) -}}
+{{- $constraint := $o.constraint | required (printf ".Values.policies[%d].constraint is required." $i) -}}
+---
+apiVersion: terraform.appvia.io/v1alpha1
+kind: Policy
+metadata:
+  name: {{ $name }}
+  annotations:
+    {{- range $k, $v := $o.annotations }}
+    {{ $k }}: "{{ $v }}"
+    {{- end }}
+  labels:
+    {{- range $k, $v := $o.labels }}
+    {{ $k }}: "{{ $v }}"
+    {{- end }}
+spec:
+  constraints: {{ $constraint | toYaml | nindent 4 }}
+{{- end }}

--- a/charts/terraform-controller/values.yaml
+++ b/charts/terraform-controller/values.yaml
@@ -121,6 +121,17 @@ rbac:
     # annotations is a collection of annotations which should be added
     annotations: {}
 
+# Allows to you to control via the helm chart the deployment of a number of
+# security policy which govern what must be enforced in the controller and by
+# the consumers.
+policies:
+#  - name: permitted_modules
+#    labels: {}
+#    annotations: {}
+#    constraint:
+#      modules:
+#        allowed: []
+
 resources: {}
   # These resources are applied to the controller
   # limits:


### PR DESCRIPTION
Adding the ability to deploy policies via the helm chart

```yaml
policies:
  - name: permitted-modules
    constraint:
      modules:
        allowed:
          - "https://github.com/appvia/*"
```