### PR TITLE
[BUGFIX] - Refuse to continue

### DIFF
--- a/pkg/controller/configuration/detect_errors.go
+++ b/pkg/controller/configuration/detect_errors.go
@@ -118,6 +118,7 @@ func (c *Controller) ensureErrorDetection(configuration *terraformv1alphav1.Conf
 			}
 		}
 
-		return reconcile.Result{}, nil
+		// if we've entered this method we cannot move forward in the reconciliation process
+		return reconcile.Result{}, controller.ErrIgnore
 	}
 }


### PR DESCRIPTION
We introduced a bug in the last commit - the output of this method should always be do not move forward
